### PR TITLE
add support for including Windows INI-style config files

### DIFF
--- a/priv/config/load_ini.config
+++ b/priv/config/load_ini.config
@@ -1,0 +1,157 @@
+%% -*- erlang-indent-level: 4; indent-tabs-mode: nil -*-
+%% Copyright (C) 2016, Jaguar Land Rover
+%%
+%% This program is licensed under the terms and conditions of the
+%% Mozilla Public License, version 2.0.  The full text of the
+%% Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
+
+%% Usage: From a setup .config file:
+%% {ok, Instructions} = file:script("$PRIV/config/load_ini.config",
+%%                                  [{'FILE', YourINIfile}])
+%% Then, either append or prepend Instructions to the other config
+%% instructions.
+%%
+
+%% ==================================================
+%% Mapping
+%% ==================================================
+
+Str = fun(B) -> binary_to_list(B) end.
+
+ConfigMap =
+[{<<"system">>, rvi_core,
+  [
+   {<<"device_key" >>        , {device_key         , Str}},
+   {<<"root_cert"  >>        , {root_cert          , Str}},
+   {<<"device_cert">>        , {device_cert        , Str}},
+   {<<"cred_dir"   >>        , {cred_dir           , Str}},
+   {<<"node_address">>       , {node_address       , Str}},
+   {<<"node_service_prefix">>, {node_service_prefix, Str}},
+   {<<"node_id">>            , {node_id            , Str}}
+  ]}
+].
+
+%% This fun converts <Grp, K, V> to a 'set_env' list, or raise an error
+%%
+ApplyMap =
+fun(Grp, K, V) ->
+	case lists:keyfind(Grp, 1, ConfigMap) of
+	    {_, App, VarMap} = Found ->
+		case lists:keyfind(K, 1, VarMap) of
+		    {_, {EVar, F}} ->
+			[{App, [{EVar, F(V)}]}];
+		    false ->
+			error({not_found, {Grp, K, V}})
+		end;
+	    false ->
+		error({not_found, {Grp, K, V}})
+	end
+end.
+
+%% ==================================================
+%% Windows INI format parser
+%% ==================================================
+
+Compact =
+fun(Gs) ->
+	lists:foldl(
+	  fun({G,Vs}, Acc) ->
+		  case orddict:find(G, Acc) of
+		      {ok, Vs0} -> orddict:store(G, Vs0 ++ Vs, Acc);
+		      error     -> orddict:store(G, Vs, Acc)
+		  end
+	  end, orddict:new(), Gs)
+end.
+
+Heading =
+fun(L) when is_binary(L) ->
+	case re:run(L, "\\[\\h*([^\\h]+)\\h*\\]", [{capture,[1],binary}]) of
+	    {match, [H]} ->
+		H;
+	    nomatch ->
+		false
+	end
+end.
+
+Cmd =
+fun(V) ->
+	case os:cmd(binary_to_list(<<"echo ", V/binary>>)) of
+	    "/bin/sh:" ++ _ ->
+		V;
+	    Res ->
+		re:replace(Res, "^(.*)\\n$", "\\1", [{return, binary}])
+	end
+end.
+
+Var =
+fun(L) ->
+	case re:run(L, "\\h*([^\\h]+)\\h*=\\h*(.*)",
+		    [{capture,[1,2],binary}]) of
+	    {match, [K, V]} ->
+		{K, Cmd(V)};
+	    _ ->
+		false
+	end
+end.
+
+Collect =
+fun C([H|T] = Ls, G, Acc) ->
+	case Var(H) of
+	    {K, V} -> C(T, G, [{K,V}|Acc]);
+	    false  -> {{G, lists:reverse(Acc)}, Ls}
+	end;
+    C([], G, Acc) ->
+	{{G, lists:reverse(Acc)}, []}
+end.
+
+Group =
+fun Grp([H|T] = Ls) ->
+    case Heading(H) of
+        false ->
+            {G, T1} = Collect(Ls, <<>>, []),
+            [G | Grp(T1)];
+        Head when is_binary(Head) ->
+            {G, T1} = Collect(T, Head, []),
+            [G | Grp(T1)]
+    end;
+    Grp([]) ->
+    []
+end.
+
+Parse =
+fun(B) ->
+	Lines =
+	    [L ||
+		L <- re:split(B, "\\n", [{return,binary}, notempty]),
+		L =/= <<>>],  %% may still contain a trailing <<>>
+	Compact(Group(Lines))
+end.
+
+%% ==================================================
+%% End parser
+%% ==================================================
+
+%% For actual mapping rules, see the ConfigMap and ApplyMap functions
+%% at the top of this script.
+Map =
+fun(Groups) ->
+	lists:flatmap(
+	  fun({G, Vars}) ->
+		  [{set_env,
+		    Compact(
+		      lists:flatmap(
+			fun({K, V}) ->
+				ApplyMap(G, K, V)
+			end, Vars))}]
+	  end, Groups)
+end.
+
+%% This function reads the Windows INI file, parses it, then
+%% transforms the parsed result into 'set_env' instructions.
+case file:read_file(FILE) of
+    {ok, B} ->
+	ParseResult = Parse(B),
+	Map(ParseResult);
+    {error, _} = Error ->
+	Error
+end.

--- a/priv/test_config/backend.config
+++ b/priv/test_config/backend.config
@@ -1,14 +1,10 @@
 %% -*- erlang -*-
 {ok, CurDir} = file:get_cwd().
+D = filename:dirname(filename:absname(SCRIPT)).
+F = filename:join(D,"rvi_core/priv/config/load_ini.config").
+I = filename:join(D, "rvi_core/priv/test_config/my_ini.config").
+{ok, Instr} = file:script(F, [{'FILE', I}]).
 [
- {include_lib, "rvi_core/priv/config/rvi_backend.config"},
- {set_env,
-  [
-   {rvi_core,
-    [{device_key, "$HOME/../../basic_backend_keys/device_key.pem"},
-     {root_cert, "$HOME/../../root_keys/root_cert.crt"},
-     {device_cert, "$HOME/../../basic_backend_keys/device_cert.crt"},
-     {cred_dir, "$HOME/../../basic_backend_creds"}
-    ]}
-  ]}
+ {include_lib, "rvi_core/priv/config/rvi_backend.config"}
+ | Instr
 ].

--- a/priv/test_config/my_ini.config
+++ b/priv/test_config/my_ini.config
@@ -1,0 +1,6 @@
+[ system ]
+
+device_key = $PWD/../basic_backend_keys/device_key.pem
+root_cert = $PWD/../root_keys/root_cert.crt
+device_cert = $PWD/../basic_backend_keys/device_cert.crt
+cred_dir = $PWD/../basic_backend_creds


### PR DESCRIPTION
Add a `setup` config script that can parse Windows INI syntax and translate contents to RVI erlang environment variables. In order for the invocation to be easier, `setup` needs to be extended, but the current approach (exemplified in `priv/config/backend.config`) doesn't require any changes in RVI code or dependencies.