### PR TITLE
add 'src' element to message

### DIFF
--- a/test/rvi_core_SUITE.erl
+++ b/test/rvi_core_SUITE.erl
@@ -543,7 +543,8 @@ handle_body(Socket, _Request, Body, _St) ->
 	   {<<"parameters">>,
 	    [ {<<"data">>, Data},
 	      {<<"sendto">>, SendTo},
-	      {<<"rvi.max_msg_size">>, _}]}
+	      {<<"rvi.max_msg_size">>, _}]},
+	   {<<"src">>, _}
 	  ]}] ->
 	    binary_to_existing_atom(SendTo, latin1)
 		! {message, [{service_name, SvcName},


### PR DESCRIPTION
Pass the local service prefix as a `"src"` element when invoking a service.

The service gets something like:
```
{"params":
  {"service_name": ...,
   "parameters": ...,
   "src": "genivi.org/device/UUID"}}
```