### PR TITLE
Release 0.5.1

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,7 +4,7 @@ Copyright (C) 2014-2016, Jaguar Land Rover
 This document is licensed under Creative Commons
 Attribution-ShareAlike 4.0 International.
 
-**Version 0.5.0**
+**Version 0.5.1**
 
 # BUILD INSTRUCTIONS FOR RVI #
 

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -9,7 +9,7 @@ Copyright (C) 2014-2016, Jaguar Land Rover
 This document is licensed under Creative Commons
 Attribution-ShareAlike 4.0 International.
 
-**Version 0.5.0**
+**Version 0.5.1**
 
 # CONFIGURING AN RVI NODE 
 

--- a/INSTALL_debian.md
+++ b/INSTALL_debian.md
@@ -3,7 +3,7 @@ Copyright (C) 2014-2016, Jaguar Land Rover
 This document is licensed under Creative Commons
 Attribution-ShareAlike 4.0 International.
 
-**Version 0.5.0**
+**Version 0.5.1**
 
 # INSTALLATION OF RVI (DEBIAN) #
 
@@ -77,7 +77,7 @@ Download the RVI package from https://github.com/PDXostc/rvi_core/releases.
 
 Then install RVI via dpkg:
 
-    sudo dpkg -i rvi_0.5.0-1_amd64.deb
+    sudo dpkg -i rvi_0.5.1-1_amd64.deb
 
 ----
 

--- a/INSTALL_raspbian.md
+++ b/INSTALL_raspbian.md
@@ -3,7 +3,7 @@ Copyright (C) 2014-2016, Jaguar Land Rover
 This document is licensed under Creative Commons
 Attribution-ShareAlike 4.0 International.
 
-**Version 0.5.0**
+**Version 0.5.1**
 
 # INSTALLATION OF RVI (RASPBIAN) #
 

--- a/INSTALL_ubuntu.md
+++ b/INSTALL_ubuntu.md
@@ -3,7 +3,7 @@ Copyright (C) 2014-2016, Jaguar Land Rover
 This document is licensed under Creative Commons
 Attribution-ShareAlike 4.0 International.
 
-**Version 0.5.0**
+**Version 0.5.1**
 
 # INSTALLATION OF RVI (UBUNTU 14.04 TRUSTY) #
 
@@ -79,7 +79,7 @@ Download the RVI package from https://github.com/PDXostc/rvi_core/releases.
 
 Then install RVI via dpkg:
 
-    sudo dpkg -i rvi_0.5.0-1ubuntu1_amd64.deb
+    sudo dpkg -i rvi_0.5.1-1ubuntu1_amd64.deb
 
 ----
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ SRC_LIST=BUILD.md \
 	deps \
 	TODO 
 
-VERSION=0.5.0
+VERSION=0.5.1
 
 all: deps compile escript
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ choices.
 
 For a high level description, with an exhaustive master use-case
 walkthrough, please see the High Level Design document 
-[here](https://wiki.automotivelinux.org/_media/eg-rvi/15-456-poc-rvi-hld_reva.pdf) (**NOTE: HLD not updated to reflect RVI Core 0.5.0**)
+[here](https://wiki.automotivelinux.org/_media/eg-rvi/15-456-poc-rvi-hld_reva.pdf) (**NOTE: HLD not updated to reflect RVI Core 0.5.1**)
 
 Packages are available for some distributions. See installation
 instructions for [Ubuntu](INSTALL_ubuntu.md), [Debian](INSTALL_debian.md),

--- a/README_ubuntu_14_04.md
+++ b/README_ubuntu_14_04.md
@@ -10,7 +10,7 @@ wget ttps://packages.erlang-solutions.com/erlang/esl-erlang/FLAVOUR_1_general/es
 sudo dpkg -i esl-erlang_18.2-1~ubuntu~precise_amd64.deb
 
 4. Install RVI
-sudo dpkg -i rvi_0.5.0-1ubuntu1_amd64.deb
+sudo dpkg -i rvi_0.5.1-1ubuntu1_amd64.deb
 
 5. Setup device keys
 Assumes that root key pair is already generated.

--- a/debian_template/changelog
+++ b/debian_template/changelog
@@ -1,4 +1,4 @@
-rvi (0.5.0-1) jessie; urgency=low
+rvi (0.5.1-1) jessie; urgency=low
 
   * Initial release
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -72,7 +72,7 @@ Go to the top directory of RVI and execute:
 An RPM file will be generated at the end of the build which can be
 installed on a Tizen box. The RPM can be found at:
 
-    ~/GBS-ROOT/local/repos/tizen/i586/RPMS/rvi-0.5.0-1.i686.rpm
+    ~/GBS-ROOT/local/repos/tizen/i586/RPMS/rvi-0.5.1-1.i686.rpm
 
 
 # UPDATING REBAR DEPENDENCIES

--- a/packaging/rvi_core.spec
+++ b/packaging/rvi_core.spec
@@ -1,10 +1,10 @@
 Summary:    Remote Vehicle Interaction Node, running on top of Erlang,
 Name:       rvi_core
-Version:    0.5.0
+Version:    0.5.1
 Release:    1
 Group:      App Framework/Application Communication
 License:    Mozilla Public License 2.0
-Source:     http://content.linuxfoundation.org/auto/downloads/rvi/rvi_core-0.5.0.tgz
+Source:     http://content.linuxfoundation.org/auto/downloads/rvi/rvi_core-0.5.1.tgz
 
 BuildRequires:  make
 BuildRequires:  glib2-devel
@@ -50,4 +50,4 @@ rm -rf $RPM_BUILD_ROOT
 %attr(644,app,users) /home/app/content/Documents/vin
 /usr/lib/systemd/system/rvi.service 
 /etc/systemd/system/multi-user.target.wants/rvi.service
-/opt/rvi-0.5.0
+/opt/rvi-0.5.1

--- a/python/rvilib.py
+++ b/python/rvilib.py
@@ -5,7 +5,7 @@
 # Mozilla Public License, version 2.0.  The full text of the 
 # Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
 #
-# rbilib.py 0.5.0
+# rvilib.py 0.5.1
 #  
 # This moduke
 from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCServer

--- a/raspbian_template/changelog
+++ b/raspbian_template/changelog
@@ -1,4 +1,4 @@
-rvi (0.5.0-1) jessie; urgency=low
+rvi (0.5.1-1) jessie; urgency=low
 
   * Initial release
 

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -4,7 +4,7 @@
        {lib_dirs, ["../deps/", "../components/"]},
        {erts, [{mod_cond, derived}, {app_file, strip}]},
        {app_file, strip},
-       {rel, "rvi", "0.5.0",
+       {rel, "rvi", "0.5.1",
         [
          kernel,
          stdlib,

--- a/rpm/SPECS/rvi-0.5.1.spec
+++ b/rpm/SPECS/rvi-0.5.1.spec
@@ -1,12 +1,12 @@
 Summary: Remote Vehicle Interaction Node
 Name: rvi
-Version: 0.5.0
+Version: 0.5.1
 Release: 1
 # Copyright: Jaguar Land Rover -
 License: Mozilla Public License v2
 Vendor: Jaguar Land Rover
 Group: Applications/System
-Source: http://content.linuxfoundation.org/auto/downloads/rvi/rvi-0.5.0.tgz
+Source: http://content.linuxfoundation.org/auto/downloads/rvi/rvi-0.5.1.tgz
 Buildroot: /var/tmp/%{name}-buildroot
 
 # Requires: 
@@ -69,4 +69,4 @@ rm -rf $RPM_BUILD_ROOT
 /etc/rc4.d
 /etc/rc5.d
 /etc/rc6.d
-/opt/rvi-0.5.0
+/opt/rvi-0.5.1

--- a/scripts/rvi_create_credential.py
+++ b/scripts/rvi_create_credential.py
@@ -267,7 +267,7 @@ cred = {
 
 
 
-encoded = jwt.encode(cred, root_key.exportKey("PEM"), algorithm='RS256')
+encoded = jwt.encode(cred, root_key.exportKey("PEM"), algorithm='HS256')
 
 # Validate
 try:

--- a/scripts/rvi_create_credential.py
+++ b/scripts/rvi_create_credential.py
@@ -267,7 +267,7 @@ cred = {
 
 
 
-encoded = jwt.encode(cred, root_key.exportKey("PEM"), algorithm='HS256')
+encoded = jwt.encode(cred, root_key.exportKey("PEM"), algorithm='RS256')
 
 # Validate
 try:

--- a/src/rvi_core.app.src
+++ b/src/rvi_core.app.src
@@ -12,7 +12,7 @@
 {application, rvi_core,
  [
   {description, ""},
-  {vsn, "0.5.0"},
+  {vsn, "0.5.1"},
   {registered, []},
   {applications, [
                   kernel,

--- a/ubuntu_template/changelog
+++ b/ubuntu_template/changelog
@@ -1,4 +1,4 @@
-rvi (0.5.0-1ubuntu1) trusty; urgency=low
+rvi (0.5.1-1ubuntu1) trusty; urgency=low
 
   * Initial release
 


### PR DESCRIPTION
- switching to a different JSON codec (which forced a bunch of type changes)
- caching authorization results for higher performance
- added support for TLS options (and turning of TLS session caching as default)
- various bug fixes, particularly a subtle bug in the fragmentation support
- some added tracing support
- added "get_node_service_prefix" in the service edge API
- some improvements in the Websocket python client
- the sample creds now use "right_to_receive" instead of "right_to_register" (but both are supported in both versions)
- updated demonstration certificates